### PR TITLE
Feat: Add new method `loader::Function::new_dummy()` for testing purpose.

### DIFF
--- a/external-crates/move/move-vm/runtime/src/loader.rs
+++ b/external-crates/move/move-vm/runtime/src/loader.rs
@@ -2394,6 +2394,29 @@ impl Function {
             })
         }
     }
+
+    pub fn new_dummy(parameter_types: Vec<Type>) -> Self {
+        Self {
+            file_format_version: 0,
+            index: Default::default(),
+            code: vec![],
+            parameters: Default::default(),
+            return_: Default::default(),
+            locals: Default::default(),
+            type_parameters: vec![],
+            native: None,
+            def_is_native: false,
+            def_is_friend_or_private: false,
+            scope: Scope::Module(ModuleId::new(
+                AccountAddress::from([0; 32]),
+                Identifier::new("test").unwrap(),
+            )),
+            name: Identifier::new("test").unwrap(),
+            return_types: vec![],
+            local_types: vec![],
+            parameter_types,
+        }
+    }
 }
 
 //


### PR DESCRIPTION
## Description 

The unit tests for `ityfuzz::move::MoveFunctionInput` need a dummy `Function` instance, but most fields of `Function` are private and we can't create one outside the `Function` module.
So I add a new method `loader::Function::new_dummy()` for this purpose.

The current not-working code is here:

https://github.com/fuzzland/ityfuzz/blob/80e5c7c5223ec09b913f5e94c2cd0e63780786ed/src/move/input.rs#L868-L884